### PR TITLE
Using ReactDOM's builtin callback for knowing when mount is finished

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A single spa plugin for React apps",
   "main": "lib/single-spa-react.js",
   "scripts": {
-    "build": "babel src --out-dir lib"
+    "build": "babel src --out-dir lib --source-maps"
   },
   "repository": {
     "type": "git",

--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -40,23 +40,22 @@ export default function singleSpaReact(userOpts) {
 }
 
 function bootstrap(opts) {
-	return new Promise((resolve, reject) => {
-		resolve();
-	});
+	return Promise.resolve();
 }
 
 function mount(opts) {
 	return new Promise((resolve, reject) => {
-		opts.ReactDOM.render(opts.React.createElement(opts.rootComponent), getRootDomEl(opts));
-		resolve();
-	});
+		const whenFinished = resolve;
+		opts.ReactDOM.render(opts.React.createElement(opts.rootComponent), getRootDomEl(opts), whenFinished);
+	})
 }
 
 function unmount(opts) {
-	return new Promise((resolve, reject) => {
-		opts.ReactDOM.unmountComponentAtNode(getRootDomEl(opts));
-		resolve();
-	});
+	return Promise
+		.resolve()
+		.then(() => {
+			opts.ReactDOM.unmountComponentAtNode(getRootDomEl(opts));
+		})
 }
 
 function getRootDomEl(opts) {


### PR DESCRIPTION
When I wrote this library, I wasn't aware that `ReactDOM.render` could potentially be asynchronous and provided a callback API for when it finished mounting an application. See https://facebook.github.io/react/docs/react-dom.html#render.

This should be totally backwards compatible, and I tested it with communications-ui and it worked great.