### PR TITLE
The lifecycle method 'mount' does receive the root component instance now

### DIFF
--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -46,7 +46,9 @@ function bootstrap(opts) {
 
 function mount(opts, props) {
   return new Promise((resolve, reject) => {
-    const whenFinished = resolve;
+    const whenFinished = function() {
+      resolve(this);
+    };
     const renderedComponent = opts.ReactDOM.render(opts.React.createElement(opts.rootComponent), getRootDomEl(opts), whenFinished);
     if (!renderedComponent.componentDidCatch && !opts.suppressComponentDidCatchWarning && atLeastReact16(opts.React)) {
       console.warn(`single-spa-react: ${props.name || props.appName || props.childAppName}'s rootComponent should implement componentDidCatch to avoid accidentally unmounting the entire single-spa application.`);


### PR DESCRIPTION
It would be great if we could pass the instantiated component down to the middle ware. This is especially useful since this (https://github.com/CanopyTax/single-spa/pull/156) PR has been merged. Here is a simple use case for this:

```js
// root-application.js
singleSpa.registerApplication('app1', () =>  {}, () => {}, {authToken: "d83jD63UdZ6RS6f70D0"});
```

```js
// app.js
export function mount(props) {
    return reactLifecycles.mount(props).then((rootComponent) => {
        rootComponent.setAuthToken(props.customProps.authToken);
    });
}
```

```js
// root.component.js
export default class Root extends React.Component {

    state = {authToken: ''};

    setAuthToken(authToken) {
        this.setState(() => ({
            authToken: authToken
        }));
    }

    render() {
        return (
            <div>
                {this.state.authToken}
            </div>
        );
    }
}
```

Our actual use case is to pass down a reference to the communication layer which we use for inter-app-communication. So there may be many other use cases as well.

Here is the angular counterpart https://github.com/CanopyTax/single-spa-angular2/pull/7