### PR TITLE
Support other render types

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ All options are passed to single-spa-react via the `opts` parameter when calling
   or `singleSpaReact({..., domElement})`.
 - `parcelCanUpdate`: (optional) A boolean that controls whether an update lifecycle will be created for the returned parcel. Note that option does not impact single-spa applications, but only parcels.
   It is true by default.
+- `renderType`: (optional) ENUM of one of the following: [ 'render', 'hydrate', 'createRoot' ]. Defaults to `'render'`. Allows you to choose which ReactDOM render method you want to use for your application.
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "single-spa-react",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "A single spa plugin for React apps",
   "main": "lib/single-spa-react.js",
   "scripts": {

--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -93,7 +93,7 @@ function mount(opts, props) {
     const rootComponentElement = opts.React.createElement(opts.rootComponent, props)
     const elementToRender = SingleSpaContext ? opts.React.createElement(SingleSpaContext.Provider, {value: props}, rootComponentElement) : rootComponentElement
     const domElement = getRootDomEl(domElementGetter)
-    const renderedComponent = opts.ReactDOM.render(elementToRender, domElement, whenFinished)
+    const renderedComponent = reactDomRender({elementToRender, domElement, whenFinished, opts})
     opts.domElement = domElement
   })
 }
@@ -114,7 +114,7 @@ function update(opts, props) {
 
     const rootComponentElement = opts.React.createElement(opts.rootComponent, props)
     const elementToRender = SingleSpaContext ? opts.React.createElement(SingleSpaContext.Provider, {value: props}, rootComponentElement) : rootComponentElement
-    const renderedComponent = opts.ReactDOM.render(elementToRender, opts.domElement, whenFinished)
+    const renderedComponent = reactDomRender({elementToRender, domElement:opts.domElement, whenFinished, opts})
   })
 }
 
@@ -149,4 +149,17 @@ function chooseDomElementGetter(opts, props) {
   } else {
     return opts.domElementGetter
   }
+}
+
+function reactDomRender({opts, elementToRender, domElement, whenFinished}) {
+  if(opts.renderType === 'createRoot') {
+    return opts.ReactDOM.createRoot(domElement).render(elementToRender, whenFinished)
+  }
+
+  if(opts.renderType === 'hydrate') {
+    return opts.ReactDOM.hydrate(elementToRender, domElement, whenFinished)
+  }
+
+  // default to this if 'renderType' is null or doesn't match the other options
+  return opts.ReactDOM.render(elementToRender, domElement, whenFinished)
 }


### PR DESCRIPTION
Mainly opens the door for concurrent (async) React, and also hydrate in case anyone has that need as well. 

Potentially fixes #41 