### PR TITLE
handle components that do not have a prototype

### DIFF
--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -75,8 +75,12 @@ function bootstrap(opts, props) {
 function mount(opts, props) {
   return new Promise((resolve, reject) => {
 
-    if (!opts.rootComponent.prototype.componentDidCatch && !opts.suppressComponentDidCatchWarning && atLeastReact16(opts.React)) {
-      console.warn(`single-spa-react: ${props.name || props.appName || props.childAppName}'s rootComponent should implement componentDidCatch to avoid accidentally unmounting the entire single-spa application.`);
+    if (!opts.suppressComponentDidCatchWarning && atLeastReact16(opts.React)) {
+      if (!opts.rootComponent.prototype) {
+        console.warn(`single-spa-react: ${props.name || props.appName || props.childAppName}'s rootComponent does not have a prototype.  If using a functional component, wrap it in an error boundary or other class that implements componentDidCatch to avoid accidentally unmounting the entire single-spa application`)
+      } else if (!opts.rootComponent.prototype.componentDidCatch) {
+        console.warn(`single-spa-react: ${props.name || props.appName || props.childAppName}'s rootComponent should implement componentDidCatch to avoid accidentally unmounting the entire single-spa application.`);
+      }
     }
 
     const domElementGetter = chooseDomElementGetter(opts, props)


### PR DESCRIPTION
If you use an arrow function component as your rootComponent for single-spa, and you do not configure babel to transpile to a named function, single-spa will crash when attempting to access the prototype's componentDidCatch.

`if (!opts.rootComponent.prototype.componentDidCatch)`

The easiest solution is to wrap in CanopyReactErrorBoundary: 

`rootComponent: CanopyReactErrorBoundary({ featureName: my-component' })(MyComponent),`

To let the developer know, and to prevent the crash, I've added a second check to see if the prototype exists.  If not, a warning is sent to the console.