### PR TITLE
adding option for createBlockingRoot render, part of new concurrent mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "single-spa-react",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "A single spa plugin for React apps",
   "main": "lib/single-spa-react.js",
   "scripts": {

--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -179,6 +179,10 @@ function reactDomRender({opts, elementToRender, domElement, whenFinished}) {
     return opts.ReactDOM.createRoot(domElement).render(elementToRender, whenFinished)
   }
 
+  if(opts.renderType === 'createBlockingRoot') {
+    return opts.ReactDOM.createBlockingRoot(domElement).render(elementToRender, whenFinished)
+  }
+
   if(opts.renderType === 'hydrate') {
     return opts.ReactDOM.hydrate(elementToRender, domElement, whenFinished)
   }


### PR DESCRIPTION
I confirmed that this change works by testing a service and having it render with both `createRoot` and `createBlockingRoot` along with the latest experimental build of react.

API reference https://reactjs.org/docs/concurrent-mode-reference.html#concurrent-mode