### PR TITLE
Pass props to loadRootComponent

### DIFF
--- a/src/single-spa-react.js
+++ b/src/single-spa-react.js
@@ -64,7 +64,7 @@ function bootstrap(opts, props) {
   } else {
     // They passed a promise that resolves with the react component. Wait for it to resolve before mounting
     return opts
-      .loadRootComponent()
+      .loadRootComponent(props)
       .then(resolvedComponent => {
         opts.rootComponent = resolvedComponent
       })


### PR DESCRIPTION
I have a use case where I'd like to load other assets in parallel with my root component and use the props in the loading logic, for example translations using a `locale` prop:

```js
// my-parcel
import React from 'react'
import singleSpaReact from 'single-spa-react'

export default singleSpaReact({
  React,
  ReactDOM,
  loadRootComponent: ({ locale }) => Promise.all([
      import('./MyComponent'),
      fetch(`/my-translations/${locale}.json`)
    ]).then(([ MyComponent, myTranslations ]) => (props) => (
      <MyComponent {...props} translations={myTranslations}/>
    )
  )
})

// my app
import Parcel from 'single-spa-react/parcel'
import parcelConfig from './my-parcel'

export default () => <Parcel config={parcelConfig} locale="en"/>

```